### PR TITLE
Add Collect Function for Remaining Balance

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -5,36 +5,43 @@ use solana_sdk::{
     signer::EncodableKey, system_instruction, transaction::Transaction,
     message::Message
 };
-
+use tracing::{error, info};
 use crate::Miner;
 
 #[derive(Parser, Debug, Clone)]
 pub struct CollectArgs {
-    #[arg(long)]
-    pub keypair: String,
+    #[arg(long, help = "The folder that contains all the keys used to collect the remaining balance.")]
+    pub key_folder: String,
 
     #[arg(long)]
     pub beneficiary: Pubkey,
 
-    #[arg(long)]
+    #[arg(long, default_value = "")]
     pub fee_payer: String,
 }
 
 impl Miner {
     pub async fn collect(&self, args: &CollectArgs) {
         let client = Miner::get_client_confirmed(&self.rpc);
-        let accounts = Self::read_keys(&args.keypair);
-        let fee_payer_account =  Keypair::read_from_file(&args.fee_payer).unwrap();
+        let accounts = Self::read_keys(&args.key_folder);
+       
+        let fee_payer_account: Keypair = if (&args.fee_payer).is_empty() {
+            accounts[0].insecure_clone() // sorry for this
+        } else {
+            Keypair::read_from_file(&args.fee_payer).unwrap()
+        };
+
+        info!("use account {} as fee payer", fee_payer_account.pubkey());
         
         let mut instructions = Vec::new();
         let mut signers = Vec::new();
-
+       
         let balance_fee_payer = client
             .get_balance(&fee_payer_account.pubkey())
             .await
             .expect("Failed to get balance");
 
-        println!("Fee payer balance: {}", balance_fee_payer);
+        info!("Fee payer balance: {}", balance_fee_payer);
 
         for keypair in accounts.iter() {
             let pubkey = keypair.pubkey();

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -62,7 +62,7 @@ impl Miner {
                 );
                 instructions.push(instruction);
                 signers.push(keypair);
-                println!("Bundling transfer of {} from {} to {}", balance, pubkey, args.beneficiary)
+                info!("Bundling transfer of {} from {} to {}", balance, pubkey, args.beneficiary)
             }
 
             if instructions.len() >= 8 {
@@ -86,18 +86,18 @@ impl Miner {
                 let estimate_transfer_fee = client.get_fee_for_message(&message).await.expect("Failed to get fee for message");
 
                 if estimate_transfer_fee > balance_fee_payer {
-                    eprintln!("Insufficient funds to pay for transaction fee");
+                    error!("Insufficient funds to pay for transaction fee");
                     return;
                 }
 
-                println!("Estimate transfer fee: {}", estimate_transfer_fee);
+                info!("Estimate transfer fee: {}", estimate_transfer_fee);
 
                 match client.send_and_confirm_transaction(&transaction).await {
                     Ok(signature) => {
-                        println!("Bundled transfer succeeded. Signature: {}", signature);
+                        info!("Bundled transfer succeeded. Signature: {}", signature);
                     }
                     Err(err) => {
-                        eprintln!("Bundled transfer failed: err {}", err);
+                        error!("Bundled transfer failed: err {}", err);
                     }
                 }
 

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -1,0 +1,86 @@
+
+use clap::Parser;
+use solana_sdk::{
+    pubkey::Pubkey, signature::{Keypair, Signer},
+    signer::EncodableKey, system_instruction, transaction::Transaction
+};
+
+use crate::Miner;
+
+#[derive(Parser, Debug, Clone)]
+pub struct CollectArgs {
+    #[arg(long)]
+    pub keypair: String,
+
+    #[arg(long)]
+    pub beneficiary: Pubkey,
+
+    #[arg(long)]
+    pub fee_payer: String,
+}
+
+impl Miner {
+    pub async fn collect(&self, args: &CollectArgs) {
+        let client = Miner::get_client_confirmed(&self.rpc);
+        let accounts = Self::read_keys(&args.keypair);
+        let fee_payer_account =  Keypair::read_from_file(&args.fee_payer).unwrap();
+
+        let mut instructions = Vec::new();
+        let mut signers = Vec::new();
+
+        for keypair in accounts.iter() {
+            let pubkey = keypair.pubkey();
+            let balance = client
+                .get_balance(&pubkey)
+                .await
+                .expect("Failed to get balance");
+            let rent_exemption = client
+                .get_minimum_balance_for_rent_exemption(0)
+                .await
+                .expect("Failed to get minimum balance for rent exemption");
+
+            if balance - rent_exemption > 0 {
+                let instruction = system_instruction::transfer(
+                    &pubkey,
+                    &args.beneficiary,
+                    balance - rent_exemption,
+                );
+                instructions.push(instruction);
+                signers.push(keypair);
+                println!("Bundling transfer of {} from {} to {}", balance, pubkey, args.beneficiary)
+            }
+
+            if instructions.len() >= 8 {
+                signers.push(&fee_payer_account);
+
+                
+                let recent_blockhash = client
+                .get_latest_blockhash()
+                .await
+                .expect("Failed to get recent blockhash");
+
+                let transaction = Transaction::new_signed_with_payer(
+                    &instructions,
+                    Some(&fee_payer_account.pubkey()),
+                    &signers,
+                    recent_blockhash,
+                );
+
+                match client.send_and_confirm_transaction(&transaction).await {
+                    Ok(signature) => {
+                        println!("Bundled transfer succeeded. Signature: {}", signature);
+                    }
+                    Err(err) => {
+                        eprintln!("Bundled transfer failed: err {}", err);
+                    }
+                }
+
+                instructions.clear();
+                signers.clear();
+            }
+        }
+        
+     
+    }
+
+}

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -68,8 +68,6 @@ impl Miner {
             if instructions.len() >= 8 {
                 signers.push(&fee_payer_account);
                 
-                
-                
                 let recent_blockhash = client
                 .get_latest_blockhash()
                 .await

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -13,10 +13,10 @@ pub struct CollectArgs {
     #[arg(long, help = "The folder that contains all the keys used to collect the remaining balance.")]
     pub key_folder: String,
 
-    #[arg(long)]
+    #[arg(long, help = "The beneficiary account that will receive the remaining balance.")]
     pub beneficiary: Pubkey,
 
-    #[arg(long, default_value = "")]
+    #[arg(long, default_value = "", help = "The keypair file to use as fee payer. If not provided, the first key in the key_folder will be used.")]
     pub fee_payer: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod batch_transfer;
 mod benchmark_rpc;
 mod bundle_mine;
 mod bundle_mine_gpu;
+mod collect;
 mod claim;
 mod constant;
 mod generate_wallet;
@@ -58,6 +59,7 @@ async fn main() {
         Command::BatchTransfer(args) => miner.batch_transfer(args).await,
         Command::JitoTipStream => miner.jito_tip_stream().await,
         Command::GenerateWallet(args) => miner.generate_wallet(args),
+        Command::Collect(args) => miner.collect(args).await,
     }
 }
 
@@ -83,6 +85,7 @@ pub enum Command {
     JitoTipStream,
     GenerateWallet(crate::generate_wallet::GenerateWalletArgs),
     BatchTransfer(crate::batch_transfer::BatchTransferArgs),
+    Collect(crate::collect::CollectArgs),
 }
 
 impl Miner {


### PR DESCRIPTION
# Description
This pull request introduces a new `collect` function that allows users to collect the remaining balance from their account while considering transaction fees. The collected balance will be transferred to a specified beneficiary address, and the transaction fees will be paid by a separate fee payer account.

# Usage
To use the collect function, run the following command:

```bash
cargo run --release -- --rpc {your_rpc} collect --key_folder {your_key_folder} --beneficiary {your_beneficiary_address} --fee-payer {fee_payer_keypair}
{your_rpc}: Replace with the URL of your RPC endpoint.
{your_key_folder}: Replace with the path to your keypair file.
{your_beneficiary_address}: Replace with the address of the beneficiary account where the remaining balance will be transferred.
{fee_payer_keypair}: Replace with the path to the keypair file of the fee payer account.
```